### PR TITLE
Option to set output directory

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,9 +8,9 @@ export default overwrite;
 
 const MODULES_DIR = __filename.slice(0, __filename.lastIndexOf("node_modules") + "node_modules".length);
 
-function overwrite(moduleName, files) {
+function overwrite(moduleName, files, options) {
   let moduleDir = getModuleDir(moduleName);
-  let newModuleDir = getNewModuleDir(moduleName);
+  let newModuleDir = getNewModuleDir(moduleName, options);
 
   rimraf.sync(newModuleDir);
   copyDir.sync(moduleDir, newModuleDir);
@@ -25,7 +25,11 @@ function overwrite(moduleName, files) {
   return require(newModuleDir);
 }
 
-function getNewModuleDir(moduleName) {
+function getNewModuleDir(moduleName, options) {
+  if(options && options.dir) {
+    return path.resolve(options.dir, moduleName)
+  }
+
   return path.resolve(MODULES_DIR, `.${pkg.name}`, moduleName);
 }
 


### PR DESCRIPTION
I needed an option to set the output directory trying to run this library inside Amazon Lambda because I did not have writing permission to the node_modules directory.